### PR TITLE
User install enum for 2.7, typo

### DIFF
--- a/part1_hls4ml_intro.md
+++ b/part1_hls4ml_intro.md
@@ -3,7 +3,8 @@
 ```
 git clone https://github.com/hls-fpga-machine-learning/hls4ml -b tutorial
 cd hls4ml
-pip install . # --user
+pip install . --user
+pip install enum --user
 ```
 
 ### Run the tool (with your favourite model, e.g. 1-layer)
@@ -24,7 +25,7 @@ hls4ml build -p my-hls-test-${FAVOURITEMODEL} -a
 or alternatively:
 ```
 cd my-hls-test-${FAVOURITEMODEL}
-vivado_hls -f build.tcl "csim=1 synth=1 cosim=1 export=1"
+vivado_hls -f build_prj.tcl "csim=1 synth=1 cosim=1 export=1"
 ```
 
 


### PR DESCRIPTION
Some simple updates after testing on the AWS instance.
hls4ml crashed without enum available and installing with pip seems like the simplest fix.

Also, the build file that gets created has a slightly different name, now fixed